### PR TITLE
Add convenience methods to proxy httpmock and handle success/error

### DIFF
--- a/lib/http-mock.js
+++ b/lib/http-mock.js
@@ -70,6 +70,16 @@ function mockTemplate() {
 					}, 0);
 
 					prom = deferred.promise;
+					prom.success = function(callback) {
+						return prom.then(function(response) {
+							return callback(response.data);
+						});
+					};
+					prom.error = function(callback) {
+						return prom.then(null, function(error) {
+							return callback(error);
+						});
+					};
 				}else{
 					prom = $http(config);
 				}
@@ -77,8 +87,63 @@ function mockTemplate() {
 				return prom;
 			}
 
-			httpMock.get = function(url, data, config){
-				return $http.get(url, data, config);
+			httpMock.get = function(url, config){
+				config = config || {};
+				config.url = url;
+				config.method = 'GET';
+
+				return httpMock(config);
+			};
+
+			httpMock.delete = function(url, config){
+				config = config || {};
+				config.url = url;
+				config.method = 'DELETE';
+
+				return httpMock(config);
+			};
+
+			httpMock.head = function(url, config){
+				config = config || {};
+				config.url = url;
+				config.method = 'HEAD';
+
+				return httpMock(config);
+			};
+
+			httpMock.jsonp = function(url, config){
+				config = config || {};
+				config.url = url;
+				config.method = 'JSONP';
+
+				return httpMock(config);
+			};
+
+			httpMock.post = function(url, data, config){
+				config = config || {};
+				config.url = url;
+				config.data = data;
+				config.method = 'GET';
+
+				return httpMock(config);
+			};
+
+			httpMock.put = function(url, data, config){
+				config = config || {};
+				config.url = url;
+				config.data = data;
+				config.method = 'PUT';
+
+				return httpMock(config);
+			};
+
+			httpMock.patch = function(url, data, config){
+				config = config || {};
+				config.url = url;
+				config.data = data;
+				config.method = 'PATCH';
+
+				return httpMock(config);
 			};
 
 			return httpMock;

--- a/lib/http-mock.js
+++ b/lib/http-mock.js
@@ -41,6 +41,26 @@ function mockTemplate() {
 
 				return expectation;
 			}
+			
+			function wrapWithSuccessError(promise) {
+				var myPromise = promise;
+				myPromise.success = function(callback) {
+					return wrapWithSuccessError(
+						myPromise.then(function(response) {
+							return callback(response.data);
+						})
+					);
+				};
+				myPromise.error = function(callback) {
+					return wrapWithSuccessError(
+						myPromise.then(null, function(error) {
+							return callback(error);
+						})
+					);
+				};
+
+				return myPromise;
+			}
 
 			function httpMock(config){
 				
@@ -66,20 +86,10 @@ function mockTemplate() {
 							response.status = 200;
 							deferred.resolve(response);
 						}
-						
+
 					}, 0);
 
-					prom = deferred.promise;
-					prom.success = function(callback) {
-						return prom.then(function(response) {
-							return callback(response.data);
-						});
-					};
-					prom.error = function(callback) {
-						return prom.then(null, function(error) {
-							return callback(error);
-						});
-					};
+					prom = wrapWithSuccessError(deferred.promise);
 				}else{
 					prom = $http(config);
 				}

--- a/lib/http-mock.js
+++ b/lib/http-mock.js
@@ -133,7 +133,7 @@ function mockTemplate() {
 				config = config || {};
 				config.url = url;
 				config.data = data;
-				config.method = 'GET';
+				config.method = 'POST';
 
 				return httpMock(config);
 			};


### PR DESCRIPTION
Adds handling for the following methods on `$http`:
* `.get(url, config)`
* `.delete(url, config)`
* `.head(url, config)`
* `.jsonp(url, config)`
* `.post(url, data, config)`
* `.put(url, data, config)`
* `.patch(url, data, config)`

Adds wrapper functions to make the promise returned behave more like the one from `$http`:
* `.success(f(data))`
* `.error(f(data))`