### PR TITLE
Remove console.log lines to fix in IE

### DIFF
--- a/lib/http-mock.js
+++ b/lib/http-mock.js
@@ -43,12 +43,9 @@ function mockTemplate() {
 			}
 
 			function httpMock(config){
-				console.log('request: ', config, expectations);
 				
 				var prom;
 				var expectation = matchExpectation(config);
-
-				console.log('matched expectation: ', expectation);
 
 				if(expectation){
 					var deferred = $q.defer();


### PR DESCRIPTION
The console.log lines in http-mock.js were causing the tests to fail in IE unless the developer console is open. I'm simply removing the lines here to get it to work.

You could also replace these with $log instead, if you want.
