### PR TITLE
Passes request config and response through interceptors stack

### DIFF
--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -10,8 +10,43 @@ function mockTemplate() {
 
 	newModule.requests = [];
 
-	newModule.config(['$provide', function($provide){
-		$provide.decorator('$http', ['$delegate', '$q', function($http, $q) {
+	newModule.config(['$provide', '$httpProvider', function($provide, $httpProvider){
+		$provide.decorator('$http', ['$delegate', '$q', '$injector', function($http, $q, $injector) {
+      var interceptors = $httpProvider.interceptors;
+
+      function getInterceptor(interceptorExpression) {
+        if (angular.isString(interceptorExpression)) {
+          return $injector.get(interceptorExpression);
+        } else {
+          return $injector.invoke(interceptorExpression);
+        }
+      }
+
+      function getTransformedRequestConfig(config) {
+        for (var i = 0; i < interceptors.length; i++) {
+          var interceptor = getInterceptor(interceptors[i]);
+
+          if (interceptor.request) {
+            config = interceptor.request(config);
+          }
+        }
+
+        return config;
+      }
+
+      function getTransformedResponse(response) {
+        // Response intreceptors are invoked in reverse order as per docs
+        for (var i = interceptors.length - 1; i >= 0; i--) {
+          var interceptor = getInterceptor(interceptors[i]);
+
+          if (interceptor.response) {
+            response = interceptor.response(response);
+          }
+        }
+
+        return response;
+      }
+
 			function endsWith(url, path){
 				var questionMarkIndex = url.indexOf('?');
 
@@ -63,10 +98,10 @@ function mockTemplate() {
 
 				return expectation;
 			}
-			
+
 			function wrapWithSuccessError(promise) {
 				var myPromise = promise;
-				
+
 				myPromise.success = function(callback) {
 					myPromise.then(function(response) {
 						callback(response.data, response.status, response.headers, response.config);
@@ -90,34 +125,36 @@ function mockTemplate() {
 
 			function httpMock(config){
 				var prom;
-				var expectation = matchExpectation(config);
+        var transformedConfig = getTransformedRequestConfig(angular.copy(config));
+				var expectation = matchExpectation(transformedConfig);
 
 				if(expectation){
 					var deferred = $q.defer();
 
-					newModule.requests.push(config);
+					newModule.requests.push(transformedConfig);
 
 					setTimeout(function(){
+            var resolvedResponse;
+
 						expectation.response = expectation.response || {};
-						
-						var response = {
-							data: expectation.response.data || {},
-							config: config,
-							headers: function(){}
-						};
+            // Important to clone the response so that interceptors don't change the expectation response
+            resolvedResponse = angular.copy(expectation.response);
+            resolvedResponse.config = transformedConfig;
+            resolvedResponse.headers = function () {};
+            resolvedResponse = getTransformedResponse(resolvedResponse);
 
-						response.status = expectation.response.status || 200;
+						resolvedResponse.status = resolvedResponse.status || 200;
 
-						if(statusIsSuccessful(response.status)){
-							deferred.resolve(response);
-						}else{
-							deferred.reject(response);
+						if (statusIsSuccessful(resolvedResponse.status)) {
+							deferred.resolve(resolvedResponse);
+						} else {
+							deferred.reject(resolvedResponse);
 						}
 
 					}, 0);
 
 					prom = wrapWithSuccessError(deferred.promise);
-				}else{
+				} else {
 					prom = $http(config);
 				}
 
@@ -184,11 +221,11 @@ function mockTemplate() {
 			};
 
 			httpMock.defaults = $http.defaults;
-			
+
 			return httpMock;
 		}]);
 	}]);
-	
+
 	newModule.clearRequests = function(){
 		newModule.requests = [];
 	};


### PR DESCRIPTION
This PR passes the request config and response through the `$httpProvider.interceptorsStack`, so that angular apps using interceptors will behave as expected when using protractor-http-mock.

I'm only using the `response` and `request` methods on each interceptor here; there are more in the interceptor api but these two are the main ones and others can be implemented at a later stage.