### PR TITLE
Add calls to transformRequest and transformResponse

### DIFF
--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -24,6 +24,18 @@ function mockTemplate() {
             }
         }
 
+        function transformData(data, headers, status, fns) {
+            if (typeof fns === 'function') {
+                data = fns(data, headers, status);
+            } else {
+                for (var i = 0; i < fns.length; i++) {
+                    data = fns[i](data, headers, status);
+                }
+            }
+
+            return data;
+        }
+
         function getTransformedRequestConfig(config) {
             for (var i = 0; i < interceptors.length; i++) {
                 var interceptor = getInterceptor(interceptors[i]);
@@ -31,6 +43,10 @@ function mockTemplate() {
                 if (interceptor.request) {
                     config = interceptor.request(config);
                 }
+            }
+
+            if (config.transformRequest) {
+                config.data = transformData(config.data, config.headers, undefined, config.transformRequest);
             }
 
             return config;
@@ -44,6 +60,13 @@ function mockTemplate() {
                 if (interceptor.response) {
                     response = interceptor.response(response);
                 }
+            }
+
+            if (response.config.transformResponse) {
+                response.data = transformData(response.data,
+                                              response.headers,
+                                              response.status,
+                                              response.config.transformResponse);
             }
 
             return response;

--- a/tests/httpMock.test.js
+++ b/tests/httpMock.test.js
@@ -147,6 +147,46 @@ describe('http mock', function(){
 						name: 'anonymous intercept test'
 					}
 				}
+			},
+			{
+				request: {
+					path: '/transform-request',
+					method: 'post',
+					data: {
+						name: 'test',
+						city: 'test city'
+					}
+				},
+				response: {
+					data: {
+						name: 'multiple transforms request test'
+					}
+				}
+			},
+			{
+				request: {
+					path: '/transform-request',
+					method: 'post',
+					data: {
+						name: 'test'
+					}
+				},
+				response: {
+					data: {
+						name: 'transform request test'
+					}
+				}
+			},
+			{
+				request: {
+					path: '/transform-response',
+					method: 'get'
+				},
+				response: {
+					data: {
+						name: 'test'
+					}
+				}
 			}
 		]);
 
@@ -397,6 +437,71 @@ describe('http mock', function(){
 				url: 'test-url.com/anonymous-intercept'
 			}).then(function(response){
 				expect(response.data.name).toBe('anonymous intercept test');
+				done();
+			});
+		});
+	});
+
+	describe('transforms', function(){
+		it('allows multiple transform requests', function(done){
+			http.post('test-url.com/transform-request', {
+					name: 'transform test'
+				}, {
+				transformRequest: [function(data){
+					data.city = 'test city';
+					return data;
+				}, function(data){
+					data.name = 'test';
+					return data;
+				}]
+			}).then(function(response){
+				expect(response.data.name).toBe('multiple transforms request test');
+				done();
+			});
+		});
+
+		it('allows a single transform requests', function(done){
+			http.post('test-url.com/transform-request', {
+					name: 'transform test'
+				}, {
+				transformRequest: function(data){
+					data.name = 'test';
+					return data;
+				}
+			}).then(function(response){
+				expect(response.data.name).toBe('transform request test');
+				done();
+			});
+		});
+
+		it('allows multiple transform responses', function(done){
+			http({
+				method: 'GET',
+				url: 'test-url.com/transform-response',
+				transformResponse: [function (data){
+					data.name = 'transform response test';
+					return data;
+				}, function(data){
+					data.city = 'test response city';
+					return data;
+				}]
+			}).then(function(response){
+				expect(response.data.name).toBe('transform response test');
+				expect(response.data.city).toBe('test response city');
+				done();
+			});
+		});
+
+		it('allows a single transform responses', function(done){
+			http({
+				method: 'GET',
+				url: 'test-url.com/transform-response',
+				transformResponse: function (data){
+					data.name = 'transform response test';
+					return data;
+				}
+			}).then(function(response){
+				expect(response.data.name).toBe('transform response test');
 				done();
 			});
 		});


### PR DESCRIPTION
Passes the data, headers, and status to transform functions, so that angular apps using transformRequest and transformResponse will work as expected.