### PR TITLE
Added support for interceptors that return a promise to resolve a config object

### DIFF
--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -52,21 +52,33 @@ function mockTemplate() {
             return config;
         }
 
-        function getTransformedResponse(response) {
-            // Response intreceptors are invoked in reverse order as per docs
-            for (var i = interceptors.length - 1; i >= 0; i--) {
-                var interceptor = getInterceptor(interceptors[i]);
-
-                if (interceptor.response) {
-                    response = interceptor.response(response);
-                }
-            }
-
+        function checkTransform(response) {
             if (response.config.transformResponse) {
                 response.data = transformData(response.data,
                                               response.headers,
                                               response.status,
                                               response.config.transformResponse);
+            }
+
+            return response;
+        }
+
+        function getTransformedResponse(response) {
+            // Response interceptors are invoked in reverse order as per docs
+            for (var i = interceptors.length - 1; i >= 0; i--) {
+                var interceptor = getInterceptor(interceptors[i]);
+
+                if (interceptor.response) {
+                    response = interceptor.response(response);
+
+                    if (!response.then) {
+                        response = $q.when(checkTransform(response));
+                    } else {
+                        response = response.then(function(resolvedResponse) {
+                            return checkTransform(resolvedResponse);
+                        });
+                    }
+                }
             }
 
             return response;
@@ -188,46 +200,51 @@ function mockTemplate() {
         function httpMock(config){
             var prom;
             var transformedConfig = getTransformedRequestConfig(angular.copy(config));
-            var expectation = matchExpectation(transformedConfig);
 
-            if(expectation){
-                var deferred = $q.defer();
+            return wrapWithSuccessError($q.when(transformedConfig).then(function(resolvedConfig) {
+                var expectation = matchExpectation(resolvedConfig);
 
-                newModule.requests.push(transformedConfig);
+                if(expectation){
+                    var deferred = $q.defer();
 
-                setTimeout(function(){
-                    var resolvedResponse;
+                    newModule.requests.push(resolvedConfig);
 
-                    expectation.response = expectation.response || {};
-                    
-                    // Important to clone the response so that interceptors don't change the expectation response
-                    resolvedResponse = angular.copy(expectation.response);
+                    setTimeout(function(){
+                        var resolvedResponse;
 
-                    resolvedResponse.config = transformedConfig;
+                        expectation.response = expectation.response || {};
 
-                    if(resolvedResponse.headers){
-                        resolvedResponse.headers = createHeaderGetterFunction(resolvedResponse.headers);
-                    }else{
-                        resolvedResponse.headers = function () {};
-                    }
-                    
-                    resolvedResponse = getTransformedResponse(resolvedResponse);
+                        // Important to clone the response so that interceptors don't change the expectation response
+                        resolvedResponse = angular.copy(expectation.response);
 
-                    resolvedResponse.status = resolvedResponse.status || 200;
+                        resolvedResponse.config = resolvedConfig;
 
-                    if (statusIsSuccessful(resolvedResponse.status)) {
-                        deferred.resolve(resolvedResponse);
-                    } else {
-                        deferred.reject(resolvedResponse);
-                    }
+                        if(resolvedResponse.headers){
+                            resolvedResponse.headers = createHeaderGetterFunction(resolvedResponse.headers);
+                        }else{
+                            resolvedResponse.headers = function () {};
+                        }
 
-                }, 0);
-                prom = wrapWithSuccessError(deferred.promise);
-            } else {
-                prom = $http(config);
-            }
+                        resolvedResponse = getTransformedResponse(resolvedResponse);
 
-            return prom;
+                        $q.when(resolvedResponse).then(function(resolvedResponse) {
+                            resolvedResponse.status = resolvedResponse.status || 200;
+
+                            if (statusIsSuccessful(resolvedResponse.status)) {
+                                deferred.resolve(resolvedResponse);
+                            } else {
+                                deferred.reject(resolvedResponse);
+                            }
+                        });
+                    }, 0);
+
+                    prom = deferred.promise;
+                } else {
+                    prom = $http(config);
+                }
+
+                return prom;
+            }));
         }
 
         httpMock.get = function(url, config){


### PR DESCRIPTION
Interceptors can return a config object, or a promise that resolves a config object. This adds support for handling either scenario before returning the response promise. 