### PR TITLE
queryString is now an optional restriction for mock matching as all the other conditions were

### DIFF
--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -133,7 +133,7 @@ function mockTemplate() {
 
             var queryStringStartIndex = url.indexOf('?');
 
-            if(queryStringStartIndex > -1){
+            if(expectationRequest.queryString && queryStringStartIndex > -1){
                 var qsParams = queryStringParse(url.substring(queryStringStartIndex, url.length));
                 match = angular.equals(expectationRequest.queryString, qsParams);
             }

--- a/tests/httpMock.test.js
+++ b/tests/httpMock.test.js
@@ -43,6 +43,17 @@ describe('http mock', function(){
 			{
 				request: {
 					method: 'GET',
+					path: '/user/search'
+				},
+				response: {
+					data: {
+						name: 'Whatever you search'
+					}
+				}
+			},
+			{
+				request: {
+					method: 'GET',
 					path: '/user/search',
 					queryString: {
 						id: '1',
@@ -413,10 +424,19 @@ describe('http mock', function(){
 		});
 	});
 
-	it('matches by query string', function(done){
-		http.get('github.com/user/search?id=1&city=ny%26ny').then(function(response){
-			expect(response.data.name).toBe('Carlos QS');
-			done();
+	describe('query string', function(){
+		it('matches by query string', function(done){
+			http.get('github.com/user/search?id=1&city=ny%26ny').then(function(response){
+				expect(response.data.name).toBe('Carlos QS');
+				done();
+			});
+		});
+
+		it('query string is optional in the mock config', function(done){
+			http.get('github.com/user/search?id=2&city=another').then(function(response){
+				expect(response.data.name).toBe('Whatever you search');
+				done();
+			});
 		});
 	});
 


### PR DESCRIPTION
For when I wish to have the same response regardless of the request query string.