### PR TITLE
Fix #50 - Wait until response is fulfilled before passing it to an interceptor

### DIFF
--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -69,15 +69,11 @@ function mockTemplate() {
                 var interceptor = getInterceptor(interceptors[i]);
 
                 if (interceptor.response) {
-                    response = interceptor.response(response);
-
-                    if (!response.then) {
-                        response = $q.when(checkTransform(response));
-                    } else {
-                        response = response.then(function(resolvedResponse) {
-                            return checkTransform(resolvedResponse);
-                        });
-                    }
+                    response = $q.when(response).then(function(value) {
+                        return interceptor.response(value);
+                    }).then(function(resolvedResponse) {
+                        return checkTransform(resolvedResponse);
+                    });
                 }
             }
 


### PR DESCRIPTION
I started debugging `protractor-http-mock` and found [this loop](https://github.com/atecarlos/protractor-http-mock/blob/master/lib/httpMock.js#L68-L82) may [call `interceptor.response`](https://github.com/atecarlos/protractor-http-mock/blob/master/lib/httpMock.js#L72) with a promise on it's second iteration.

This change will use `response` always as a promise so the interceptor will always get the `response` object and not the promise.