### PR TITLE
Possible fix: Response transformed for each interceptors

### DIFF
--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -36,6 +36,16 @@ function mockTemplate() {
             return data;
         }
 
+        function testJson(string){
+          try {
+            angular.fromJson(string);
+          } catch (e) {
+            return false;
+          }
+
+          return true;
+        }
+
         function getTransformedRequestConfig(config) {
             for (var i = 0; i < interceptors.length; i++) {
                 var interceptor = getInterceptor(interceptors[i]);
@@ -105,6 +115,10 @@ function mockTemplate() {
         }
 
         function matchData(expectationRequest, config){
+            if (angular.isString(config.data) && testJson(config.data)){
+                config.data = angular.fromJson(config.data);
+            }
+
             return matchProperty('data', expectationRequest, config);
         }
 

--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -71,14 +71,15 @@ function mockTemplate() {
                 if (interceptor.response) {
                     response = interceptor.response(response);
 
-                    if (!response.then) {
-                        response = $q.when(checkTransform(response));
-                    } else {
-                        response = response.then(function(resolvedResponse) {
-                            return checkTransform(resolvedResponse);
-                        });
-                    }
                 }
+            }
+
+            if (!response.then) {
+                response = $q.when(checkTransform(response));
+            } else {
+                response = response.then(function(resolvedResponse) {
+                    return checkTransform(resolvedResponse);
+                });
             }
 
             return response;


### PR DESCRIPTION
Looping on each interceptors while applying the response's configured
transformResponse (array of fn or single closure) applies those
transform many more times than expected.