### PR TITLE
Add ArrayBuffer support for mock matching and response

### DIFF
--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -103,7 +103,11 @@ function mockTemplate() {
         }
 
         function matchProperty(property, expectationRequest, config){
-            return !expectationRequest[property] || angular.equals(expectationRequest[property], config[property]);
+            if (property == 'data' && config[property] instanceof ArrayBuffer) {
+              return !expectationRequest[property] || angular.equals(expectationRequest[property], new Int8Array(config[property]));
+            } else {
+              return !expectationRequest[property] || angular.equals(expectationRequest[property], config[property]);
+            }
         }
 
         function matchParams(expectationRequest, config){
@@ -207,6 +211,9 @@ function mockTemplate() {
         function httpMock(config){
             var prom;
             var transformedConfig = getTransformedAndInterceptedRequestConfig(angular.copy(config));
+            if (config.data instanceof ArrayBuffer) {
+              transformedConfig.data = config.data.slice(0)
+            }
 
             return wrapWithSuccessError($q.when(transformedConfig).then(function(resolvedConfig) {
                 var expectation = matchExpectation(resolvedConfig);
@@ -329,6 +336,17 @@ function getExpectationsString(expectations){
     var printExpectations = [];
 
     for(var i=0; i< expectations.length; i++){
+        if (expectations[i].request.data && expectations[i].request.data instanceof ArrayBuffer) {
+            expectations[i].request.data = new Int8Array(expectations[i].request.data)
+        }
+        if (expectations[i].response.data && expectations[i].response.data instanceof ArrayBuffer) {
+            var view = new Int8Array(expectations[i].response.data)
+            var arr = []
+            for (var ii = 0 ; ii < view.length ; ii++) {
+                arr.push(view[ii])
+            }
+            expectations[i].response.data = arr
+        }
         printExpectations.push(JSON.stringify(expectations[i]));
     }
 


### PR DESCRIPTION
Allows us to match ArrayBuffer requests against mocks of the same type. Mocks can also respond with an ArrayBuffer. 