### PR TITLE
Set as default an empty header object for http requests.

### DIFF
--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -205,6 +205,8 @@ function mockTemplate() {
         }
 
         function httpMock(config){
+            config.headers = config.headers || {};
+
             var prom;
             var transformedConfig = getTransformedAndInterceptedRequestConfig(angular.copy(config));
 


### PR DESCRIPTION
Some applications (for example [satellizer](https://github.com/sahat/satellizer)) expect that headers is an object, unfortunately in httpMock it is undefined.  This pull request changes the default value of headers to an empty object.