### PR TITLE
Support undefined response header parameter

### DIFF
--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -199,7 +199,11 @@ function mockTemplate() {
         }
 
         function createHeaderGetterFunction(responseHeaders){
-            return function(headerName){
+            return function(headerName) {
+                if (angular.isUndefined(headerName)) {
+                    return responseHeaders;
+                }
+
                 return responseHeaders[headerName];
             }
         }


### PR DESCRIPTION
The `$http` service response object header getter function [returns the full headers object](https://github.com/angular/angular.js/blob/master/src/ng/http.js#L212) if the header name parameter is undefined. This simply mimics that behavior.