### PR TITLE
feat(transformRequest): Support FormData in requests

### DIFF
--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -43,7 +43,10 @@ function mockTemplate() {
                                               undefined,
                                               requestConfig.transformRequest);
             }
-
+            // Support requests sent as FormData
+            if (requestConfig.data instanceof FormData && requestConfig.data.representation) {
+                requestConfig.data = requestConfig.data.representation;
+            }
             return requestConfig;
         }
 

--- a/tests/httpMock.test.js
+++ b/tests/httpMock.test.js
@@ -224,6 +224,21 @@ describe('http mock', function(){
 			},
 			{
 				request: {
+					path: '/formdata',
+					method: 'post',
+					data: {
+						name: 'test',
+						city: 'test city'
+					}
+				},
+				response: {
+					data: {
+						name: 'formdata works!'
+					}
+				}
+			},
+			{
+				request: {
 					path: '/transform-request',
 					method: 'post',
 					data: {
@@ -700,6 +715,27 @@ describe('http mock', function(){
 				expect(response.data.name).toBe('transform request test');
 				done();
 			});
+		});
+
+		it('allows requests to send data as FormData', function(done){
+                        var fd = new FormData();
+                        fd.append('name', 'test');
+                        fd.append('city', 'test city');
+                        fd.representation = {
+                            name: 'test',
+                            city: 'test city'
+                        };
+                        http.post('test-url.com/formdata', {}, {
+                            transformRequest: function(data) {                                
+                                return fd;
+                            },
+                            headers: {
+                                'Content-Type': undefined
+                            }
+                        }).then(function(response){
+                            expect(response.data.name).toBe('formdata works!');
+                            done();
+                        });
 		});
 
 		it('allows multiple transform responses', function(done){


### PR DESCRIPTION
This feature allows to match a request that contains FormData. It requires to extend in FormData.prototype to keep track of appends in a property called "representation".

Sample code for extending FormData.prototype:

FormData.prototype.representation = {};
FormData.prototype._append = FormData.prototype.append;
FormData.prototype.append = function(key, value) {
    this.representation[key] = value;
    this._append(key, value);
};