### PR TITLE
header manipulation in request interceptors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 .grunt
 _SpecRunner.html
 tests/bundle/
+.idea

--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -258,8 +258,10 @@ function mockTemplate() {
             }));
         }
 
+        var defaultConfig = {'headers': {}};
+
         httpMock.get = function(url, config){
-            config = config || {};
+            config = config || defaultConfig;
             config.url = url;
             config.method = 'GET';
 
@@ -267,7 +269,7 @@ function mockTemplate() {
         };
 
         httpMock.delete = function(url, config){
-            config = config || {};
+            config = config || defaultConfig;
             config.url = url;
             config.method = 'DELETE';
 
@@ -275,7 +277,7 @@ function mockTemplate() {
         };
 
         httpMock.head = function(url, config){
-            config = config || {};
+            config = config || defaultConfig;
             config.url = url;
             config.method = 'HEAD';
 
@@ -283,7 +285,7 @@ function mockTemplate() {
         };
 
         httpMock.jsonp = function(url, config){
-            config = config || {};
+            config = config || defaultConfig;
             config.url = url;
             config.method = 'JSONP';
 
@@ -291,7 +293,7 @@ function mockTemplate() {
         };
 
         httpMock.post = function(url, data, config){
-            config = config || {};
+            config = config || defaultConfig;
             config.url = url;
             config.data = data;
             config.method = 'POST';
@@ -300,7 +302,7 @@ function mockTemplate() {
         };
 
         httpMock.put = function(url, data, config){
-            config = config || {};
+            config = config || defaultConfig;
             config.url = url;
             config.data = data;
             config.method = 'PUT';
@@ -309,7 +311,7 @@ function mockTemplate() {
         };
 
         httpMock.patch = function(url, data, config){
-            config = config || {};
+            config = config || defaultConfig;
             config.url = url;
             config.data = data;
             config.method = 'PATCH';


### PR DESCRIPTION
 In the previous version, we couldn't have interceptors which manipulated headers of HTTP requests. I just added a 'headers' element to the config of the httpInterceptors' requests. With this, manipulation of headers is possible in the request interceptors.