### PR TITLE
Using progrator from grunt package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 .grunt
 _SpecRunner.html
 tests/bundle/
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ install:
 before_script:
   - npm install -g grunt-cli
 script:
-  - node_modules/grunt-protractor-runner/node_modules/.bin/webdriver-manager update
+  - npm run webdriver-update
   - npm test

--- a/README.md
+++ b/README.md
@@ -210,5 +210,5 @@ Included in the code base is an extensive list examples on how to use all the fe
 To run these tests locally, please follow these steps from the root directory:
 
 1. `npm install`
-2. `node_modules/.bin/webdriver-manager update`
+2. `npm webdriver-update`
 3. `npm run example`

--- a/example/protractor-conf.js
+++ b/example/protractor-conf.js
@@ -15,18 +15,17 @@ var config = {
 };
 
 if (process.env.TRAVIS) {
-  //Run PhantomJS on Travis
-  config.capabilities = {
-    browserName: 'phantomjs',
-    'phantomjs.binary.path': require('phantomjs').path,
-    'phantomjs.ghostdriver.cli.args': ['--loglevel=DEBUG'],
-    shardTestFiles: true,
-    maxInstances: 2
-  };
+    //Run PhantomJS on Travis
+    config.capabilities = {
+        browserName: 'phantomjs',
+        'phantomjs.binary.path': require('phantomjs').path,
+        'phantomjs.ghostdriver.cli.args': ['--loglevel=DEBUG'],
+        shardTestFiles: true,
+        maxInstances: 2
+    };
 } else {
-  config.capabilities = {
-    browserName: 'chrome'
-  }
-  config.chromeDriver= '../node_modules/protractor/selenium/chromedriver';
+    config.capabilities = {
+      browserName: 'chrome'
+    };
 }
 exports.config = config;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "example": "grunt example",
-    "test": "node_modules/.bin/grunt verify"
+    "test": "node_modules/.bin/grunt verify",
+    "webdriver-update": "node_modules/grunt-protractor-runner/node_modules/protractor/bin/webdriver-manager update"
   },
   "author": "Carlos Atencio",
   "license": "BSD-2-Clause",
@@ -17,8 +18,7 @@
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-jasmine-node": "~0.2.1",
     "grunt-protractor-runner": "^1.1.4",
-    "phantomjs": "2.1.3",
-    "protractor": "2.5.1"
+    "phantomjs": "2.1.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Grunt-protractor-runner comes with it's own progractor, so there is no need to install it as a separate module. This was problematic for me because versions installed would be slightly different and it wouldn't work. 

Removed standalone protractor and using the one from grunt now. Hope it helps. 