### PR TITLE
Add ability to set a responseDelay value.

### DIFF
--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -11,7 +11,7 @@ function mockTemplate() {
     newModule.requests = [];
 
     newModule.config(['$provide', '$httpProvider', function($provide, $httpProvider){
-        
+
         $provide.decorator('$http', ['$delegate', '$q', '$injector', function($http, $q, $injector) {
 
         var interceptors = $httpProvider.interceptors;
@@ -135,7 +135,7 @@ function mockTemplate() {
         }
 
         function matchQueryString(expectationRequest, config){
-            var match = true, 
+            var match = true,
                 url = config.url;
 
             var queryStringStartIndex = url.indexOf('?');
@@ -220,6 +220,8 @@ function mockTemplate() {
 
                     newModule.requests.push(resolvedConfig);
 
+                    var delay = expectation.responseDelay || 0;
+
                     setTimeout(function(){
                         var resolvedResponse;
 
@@ -247,7 +249,7 @@ function mockTemplate() {
                                 deferred.reject(resolvedResponse);
                             }
                         });
-                    }, 0);
+                    }, delay);
 
                     prom = deferred.promise;
                 } else {


### PR DESCRIPTION
Obviously more documentation and testing is needed, but I was wondering whether there would be any want for adding this feature to the main repository.

This provided to be useful when I wanted mocked calls to hang in order to test our loading icon.

```
mock([{
    request: { },
    response: { },
    responseDelay: 1000 // milliseconds
}]);
```