### PR TITLE
Override defaults when initializing

### DIFF
--- a/lib/initData.js
+++ b/lib/initData.js
@@ -55,7 +55,7 @@ module.exports = function(mocks, skipDefaults){
 	mocks = mocks || [];
 	
 	if(!skipDefaults){
-		mocks = mocks.concat(getDefaultKeys(mocksConfig));
+		mocks = getDefaultKeys(mocksConfig).concat(mocks);
 	}
 
 	for(var i = 0; i < mocks.length; i++){


### PR DESCRIPTION
Currently the defaults take precedence on the provided mocks.