### PR TITLE
Fix default conf file name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We can also configure our root directory where the mocks and protractor configur
   	onPrepare: function(){
     	require('protractor-http-mock').config = {
 			rootDirectory: __dirname, // default value: process.cwd()
-			protractorConfig: 'my-protractor-config.conf' // default value: 'protractor.conf'
+			protractorConfig: 'my-protractor-config.conf' // default value: 'protractor-conf.js'
     	};
   	}
 


### PR DESCRIPTION
There is a wrong default file name in the code example. Related to c2189e3a0e9599236708e381a6ecc673e08b8a39