### PR TITLE
Add regex matching on path.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,6 +73,7 @@ module.exports = function(grunt) {
     grunt.registerTask('host-example', ['connect:example:keepalive']);
     grunt.registerTask('example', ['connect:example', 'protractor:example']);
     grunt.registerTask('test', ['jasmine_node']);
+    grunt.registerTask('lint', ['jshint']);
     grunt.registerTask('client-test', ['browserify:test', 'jasmine:test']);
 
     grunt.registerTask('verify', ['test', 'client-test', 'example']);

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Protractor Mock
-A NodeJS module to be used alongside [Protractor](https://github.com/angular/protractor) to facilitate setting up mocks for HTTP calls for the AngularJS applications under test. 
+A NodeJS module to be used alongside [Protractor](https://github.com/angular/protractor) to facilitate setting up mocks for HTTP calls for the AngularJS applications under test.
 
 This allows the developer to isolate the UI and client-side application code in our tests without any dependencies on an API.
 
@@ -69,11 +69,11 @@ Make sure to clean up after test execution. This should be typically done in the
 	afterEach(function(){
 	  mock.teardown();
 	});
-	
+
 Please note that the `mock()` function needs to be called before the browser opens. If you have different mock data for different tests, please make sure that, either the tests always start in a new browser window, or that its possible to setup all the mocks for each test case before any of tests start running.
 
 ### Mock files
-Mocks can also be loaded from physical files located in the `mocks.dir` directory that we defined in our configuration: 
+Mocks can also be loaded from physical files located in the `mocks.dir` directory that we defined in our configuration:
 
   	tests
 	    e2e
@@ -103,6 +103,7 @@ The full GET schema for defining your mocks is as follows:
 	  request: {
 	    path: '/products/1/items',
 	    method: 'GET',
+			regex: false, // Boolean to enable Regular Expression matching on path. This is an optional field.
 	    params: { // These match params as they would be passed to the $http service. This is an optional field.
 	      page: 2,
 	      status: 'onsale'
@@ -127,6 +128,7 @@ A full mock for a POST call takes the following options:
 	  request: {
 	    path: '/products/1/items',
 	    method: 'POST',
+			regex: false, // Boolean to enable Regular Expression matching on path. This is an optional field.
 	    data: { // These match POST data. This is an optional field.
 	      status: 'onsale',
 	      title: 'Blue Jeans',
@@ -151,7 +153,7 @@ Defining `params`, `queryString`, `headers`, or `data` will help the plugin matc
 Headers must be defined as the headers that will be used in the http call. Therefore, if in the code to be tested, the headers are defined using properties with function values, these functions will be evaluated as per the $http specification and matched by end result.
 
 #### Response
-The default `status` value is 200 if none is specified. 
+The default `status` value is 200 if none is specified.
 
 An optional `delay` value can be set on the response to assert any state that occurs when waiting for the response in your application, i.e. loading messages or spinners. Please note that UI tests with timing expectations can be somewhat unstable and provide inconsistent results. Please use this feature carefully.
 
@@ -212,7 +214,7 @@ These will dynamically modify your current set of mocks, and any new request tha
 
 Plugins can be used to extend the matching functionality of protractor-http-mock. These are separate from protractor plugins.
 
-A plugin can be defined as either an NPM package or a function. 
+A plugin can be defined as either an NPM package or a function.
 
 They can be declared in your protractor configuration to be consumed by all your tests:
 
@@ -225,7 +227,7 @@ They can be declared in your protractor configuration to be consumed by all your
     }
 
 or in each individual test:
-	
+
 	mock([
 		//mocks go here
 	], [
@@ -243,7 +245,7 @@ See this [sample plugin](https://github.com/atecarlos/protractor-http-mock-sampl
 ### Defaults
 
 If necessary, default mocks and plugins can be skipped for a particular test simply by passing true at the end of your `mock` call:
-	
+
 	mock(mocks, plugins, true);
 
 

--- a/example/app/app.js
+++ b/example/app/app.js
@@ -16,13 +16,20 @@ angular
 				return $http({ method: 'POST', url: '/users/new', data: data });
 			},
 			getBy: function(name, city){
-				return $http({ 
-					method: 'GET', 
+				return $http({
+					method: 'GET',
 					url: '/users',
 					params: {
 						name: name,
 						city: city
 					}
+				});
+			},
+			getById: function(id){
+				console.log(id);
+				return $http({
+					method: 'GET',
+					url: '/users/' + id
 				});
 			},
 			getByQuery: function(name, city){
@@ -164,6 +171,12 @@ angular
 
 		self.search = function(){
 			userService.getBy(self.query, self.queryCity || undefined)
+				.then(searchHandler)
+				.catch(catchHandler);
+		};
+
+		self.searchById = function() {
+			userService.getById(self.query)
 				.then(searchHandler)
 				.catch(catchHandler);
 		};

--- a/example/index.html
+++ b/example/index.html
@@ -37,6 +37,7 @@
 				<button id="user-search-button" ng-click="ctrl.search()">Search</button>
 				<button id="user-search-by-query-button" ng-click="ctrl.searchByQuery()">Search</button>
 				<button id="user-search-external-by-query-button" ng-click="ctrl.searchExternal()">Search</button>
+				<button id="user-search-by-id-button" ng-click="ctrl.searchById()">Search by ID</button>
 			</div>
 
 			<div class="form">

--- a/example/spec/regex.spec.js
+++ b/example/spec/regex.spec.js
@@ -1,0 +1,55 @@
+var mock = require('../../index'),
+	get = require('./get');
+
+describe('match path with regex', function(){
+	beforeEach(function(){
+		mock([
+			{
+				request: {
+					path: '\\/users\\/[0-9]',
+					method: 'GET',
+					regex: true
+				},
+				response: {
+					status: 200,
+					data: {
+						name: 'User with int id'
+					}
+				}
+			},
+			{
+				request: {
+					path: '\\/users\\/[^0-9]',
+					method: 'GET',
+					regex: true
+				},
+				response: {
+					status: 400,
+					data: {
+						error: 'Not a number'
+					}
+				}
+			}
+		]);
+	});
+
+	afterEach(function(){
+		mock.teardown();
+	});
+
+	it('match on int id', function(){
+		get();
+
+		var searchButton = element(by.id('user-search-by-id-button'));
+
+		element(by.id('user-query')).sendKeys('1');
+		searchButton.click();
+
+		expect(element(by.id('user-data')).getText()).toContain('User with int id');
+
+		element(by.id('user-query')).clear().sendKeys('abc');
+		searchButton.click();
+
+		expect(element(by.id('errorMsg')).getText()).toBe('Not a number');
+	});
+});

--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -92,6 +92,11 @@ function mockTemplate() {
             return response;
         }
 
+        function matchRegex(pattern, string){
+            var regex = new RegExp(pattern);
+            return regex.test(string);
+        }
+
         function endsWith(url, path){
             var questionMarkIndex = url.indexOf('?');
 
@@ -156,7 +161,7 @@ function mockTemplate() {
 
         function matchByPlugins(expectationRequest, config){
             var match = true;
-            
+
             if(plugins.length > 0){
                 match = plugins.reduce(function(value, plugin){
                     return plugin(expectationRequest, config) && value;
@@ -168,7 +173,8 @@ function mockTemplate() {
 
         function match(config, expectationRequest){
             return  matchMethod(expectationRequest, config) &&
-                    endsWith(config.url, expectationRequest.path) &&
+                    (expectationRequest.regex ? matchRegex(expectationRequest.path, config.url)
+                                              : endsWith(config.url, expectationRequest.path)) &&
                     matchParams(expectationRequest, config) &&
                     matchData(expectationRequest, config) &&
                     matchQueryString(expectationRequest, config) &&
@@ -219,7 +225,7 @@ function mockTemplate() {
                 }
 
                 return responseHeaders[headerName];
-            }
+            };
         }
 
         function httpMock(config){
@@ -388,7 +394,7 @@ module.exports = function(expectations, plugins){
     var template = templateString.substring(templateString.indexOf('{') + 1, templateString.lastIndexOf('}'));
     var pluginsString = getPluginsString(plugins);
 
-    var newFunc = 
+    var newFunc =
         template
             .replace(/'<place_content_here>'/, '[' + getExpectationsString(expectations) + ']')
             .replace(/'<place_query_string_parse_here>'/, queryString.parse.toString())

--- a/lib/initData.js
+++ b/lib/initData.js
@@ -1,3 +1,4 @@
+/* globals browser */
 'use strict';
 
 var httpMock = require('./httpMock'),
@@ -6,7 +7,7 @@ var httpMock = require('./httpMock'),
 
 function getConfig(){
 	var config = defaultConfig;
-	
+
 	if(module.exports.config){
 		config.rootDirectory = module.exports.config['rootDirectory'] || config.module.rootDirectory;
 	}
@@ -29,17 +30,13 @@ function readMockFile(mockDirectory, mock){
 	return require(path.join(mockDirectory, mock));
 }
 
-function getDefaultKeys(mocksConfig){
-	return mocksConfig.default && mocksConfig.default.length > 0 ? mocksConfig.default : [];
-}
-
 function buildMocks(mocks, skipDefaults){
 	var data = [],
 		config = getConfig(),
 		mockDirectory = path.join(config.rootDirectory, config.mocks.dir);
 
 	mocks = mocks || [];
-	
+
 	if(!skipDefaults){
 		mocks = config.mocks.default.concat(mocks);
 	}
@@ -47,13 +44,13 @@ function buildMocks(mocks, skipDefaults){
 	for(var i = 0; i < mocks.length; i++){
 		// TODO: add validation check
 		var dataModule = typeof mocks[i] === 'string' ? readMockFile(mockDirectory, mocks[i]) : mocks[i];
-		
+
 		if(Array.isArray(dataModule)){
 			data = data.concat(dataModule);
 		}else{
 			data.push(dataModule);
 		}
-		
+
 	}
 
 	return data;
@@ -97,32 +94,32 @@ module.exports.teardown = function(){
 
 module.exports.requestsMade = function() {
 	return browser.executeAsyncScript(function () {
-		var httpMock = angular.module("httpMock");
-		var callback = arguments[arguments.length - 1]
+		var httpMock = angular.module('httpMock');
+		var callback = arguments[arguments.length - 1];
 		callback(httpMock.requests);
 	});
 };
 
 module.exports.clearRequests = function(){
 	return browser.executeAsyncScript(function () {
-		angular.module("httpMock").clearRequests();
-		var callback = arguments[arguments.length - 1]
+		angular.module('httpMock').clearRequests();
+		var callback = arguments[arguments.length - 1];
 		callback(true);
 	});
 };
 
 module.exports.add = function(mocks){
 	return browser.executeAsyncScript(function () {
-		angular.module("httpMock").addMocks(arguments[0]);
-		var callback = arguments[arguments.length - 1]
+		angular.module('httpMock').addMocks(arguments[0]);
+		var callback = arguments[arguments.length - 1];
 		callback(true);
 	}, mocks);
 };
 
 module.exports.remove = function(mocks){
 	return browser.executeAsyncScript(function () {
-		angular.module("httpMock").removeMocks(arguments[0]);
-		var callback = arguments[arguments.length - 1]
+		angular.module('httpMock').removeMocks(arguments[0]);
+		var callback = arguments[arguments.length - 1];
 		callback(JSON.stringify(true));
 	}, mocks);
 };

--- a/tests/regex.test.js
+++ b/tests/regex.test.js
@@ -1,0 +1,21 @@
+describe('regex match', function(){
+	var http;
+
+	beforeAll(function(){
+		http = window.__getHttp();
+	});
+
+	it('matches any', function(done){
+		http.get('/regex/d3ce5994-e662-4223-9968-9fc01694f08f').then(function(response){
+			expect(response.data).toBe('regex any match');
+			done();
+		});
+	});
+
+	it('matches number', function(done){
+		http.get('/regex/1').then(function(response){
+			expect(response.data).toBe('regex number match');
+			done();
+		});
+	});
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -254,6 +254,26 @@
 			response: {
 				data: 'plugin match works!'
 			}
+		},
+		{
+			request: {
+				path: 'regex\\/.*',
+				regex: true,
+				method: 'get',
+			},
+			response: {
+				data: 'regex any match'
+			}
+		},
+		{
+			request: {
+				path: '\\/regex\\/[0-9]',
+				regex: true,
+				method: 'get',
+			},
+			response: {
+				data: 'regex number match'
+			}
 		}
 	];
 


### PR DESCRIPTION
Added `regex` property on mocks to enable Regex matching on path property.
To support JSON files and javascript objects, I've used the approach.
With this, all regex patterns are interpreted as strings, and proper escapings of path slashes etc. are necessary. See the examples for details on this.

Further more cleaned some minor jshint cleanup.

Implements #89 