### PR TITLE
Add LICENSE File

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,45 @@
+COPYRIGHT
+
+All contributions by Carlos Atencio:
+Copyright (c) 2014, 2015, 2016 Carlos Atencio
+All rights reserved.
+
+All other contributions:
+Copyright (c) 2014, 2015, 2016, the respective contributors
+All rights reserved.
+
+protractor-http-mock uses a shared copyright model: each contributor holds copyright over
+their contributions to protractor-http-mock. The project versioning records all such
+contribution and copyright details. If a contributor wants to further mark
+their specific copyright on a particular contribution, they should indicate
+their copyright solely in the commit message of the change when it is
+committed.
+
+LICENSE
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met: 
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer. 
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+CONTRIBUTION AGREEMENT
+
+By contributing to the atecarlos/protractor-http-mock repository through 
+pull-request, comment, or otherwise, the contributor releases their content to the
+license and copyright terms herein.
+

--- a/README.md
+++ b/README.md
@@ -263,3 +263,7 @@ To run these tests locally, please follow these steps from the root directory:
 1. `npm install`
 2. `npm run webdriver-update`
 3. `npm run example`
+
+## LICENSE
+
+Please see [LICENSE](./LICENSE)


### PR DESCRIPTION
This PR seeks to add a `LICENSE` file clarifying the software license for the repo.  It's based off of the original author's choice of the BSD-2-Clause license found here:
https://github.com/atecarlos/protractor-http-mock/blob/master/package.json#L12

See this for more detail:
https://opensource.org/licenses/BSD-2-Clause

I've also added a link from the `README` to the `LICENSE`

Please let me know if this is appropriate, thanks!