### PR TITLE
Only remove this mock module, not all, in teardown

### DIFF
--- a/lib/initData.js
+++ b/lib/initData.js
@@ -89,7 +89,7 @@ module.exports = function(mocks, plugins, skipDefaults){
 
 module.exports.teardown = function(){
 	var ptor = getProtractorInstance();
-	ptor.clearMockModules();
+	ptor.removeMockModule('httpMock');
 };
 
 module.exports.requestsMade = function() {


### PR DESCRIPTION
Hi @atecarlos, I had trouble using this library because it was clearing all the mock modules I was adding when it should only clear its own. Here is a fix.

Cheers,
Henry