### PR TITLE
mock identification for other interceptors

### DIFF
--- a/example/spec/requestsMade.spec.js
+++ b/example/spec/requestsMade.spec.js
@@ -46,23 +46,23 @@ describe('requests made', function(){
 
 	it('can evaluate requests made', function(){
 		expect(mock.requestsMade()).toEqual([
-			{ url : '/default', method : 'GET' },
-			{ url : '/users', method : 'GET' }
+			{ url : '/default', method : 'GET', mock: 1 },
+			{ url : '/users', method : 'GET', mock: 1 }
 		]);
 		
 		element(by.model('ctrl.newUser')).sendKeys('my-new-user');
 		element(by.css('.form #save')).click();
 
 		expect(mock.requestsMade()).toEqual([
-			{ url : '/default', method : 'GET' },
-			{ url : '/users', method : 'GET' },
-			{ data : { name : 'my-new-user' }, url : '/users/new', method : 'POST' }
+			{ url : '/default', method : 'GET', mock: 1 },
+			{ url : '/users', method : 'GET', mock: 1 },
+			{ data : { name : 'my-new-user' }, url : '/users/new', method : 'POST', mock: 1 }
 		]);
 	});
 
 	it('can evaluate just the last request made', function(){
 		mock.requestsMade().then(function(requests){
-			expect(requests[1]).toEqual({ url : '/users', method : 'GET' })
+			expect(requests[1]).toEqual({ url : '/users', method : 'GET', mock: 1 })
 		});
 	});
 

--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -49,6 +49,9 @@ function mockTemplate() {
         }
 
         function getTransformedAndInterceptedRequestConfig(requestConfig) {
+
+            requestConfig.mock = 1; // so interceptors can detect a mock
+            
             for (var i = 0; i < interceptors.length; i++) {
                 var interceptor = getInterceptor(interceptors[i]);
 

--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -83,6 +83,9 @@ function mockTemplate() {
         }
 
         function getTransformedAndInterceptedResponse(response) {
+
+            response.mock = 1; // so interceptors can detect mocked responses
+
             response = transformResponse(response);
 
             // Response interceptors are invoked in reverse order as per docs


### PR DESCRIPTION
since protractor-http-mock executes the request() method of the interceptors on it's own, it might happen that some fragile interceptors might work incorrectly when called more often than once per request (1 time by e.g. $http.get and one more time by protractor-http-mock). Since all protractor-http-mock request() calls now contain the mock = 1 property, these interceptors can filter the protractor-http-mock request calls and therefore work correctly.