### PR TITLE
Instantiate interceptor only once

### DIFF
--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -15,15 +15,13 @@ function mockTemplate() {
 
         $provide.decorator('$http', ['$delegate', '$q', '$injector', function($http, $q, $injector) {
 
-        var interceptors = $httpProvider.interceptors;
+        var interceptors = [];
 
-        function getInterceptor(interceptorExpression) {
-            if (angular.isString(interceptorExpression)) {
-                return $injector.get(interceptorExpression);
-            } else {
-                return $injector.invoke(interceptorExpression);
-            }
-        }
+        angular.forEach($httpProvider.interceptors, function(interceptorExpression) {
+            var interceptor = angular.isString(interceptorExpression) ?
+                $injector.get(interceptorExpression) : $injector.invoke(interceptorExpression);
+            interceptors.push(interceptor);
+        });
 
         function transformData(data, headers, status, fns) {
             if (typeof fns === 'function') {
@@ -50,7 +48,7 @@ function mockTemplate() {
 
         function getTransformedAndInterceptedRequestConfig(requestConfig) {
             for (var i = 0; i < interceptors.length; i++) {
-                var interceptor = getInterceptor(interceptors[i]);
+                var interceptor = interceptors[i];
 
                 if (interceptor.request) {
                     $q.when(interceptor.request(requestConfig)).then(function(interceptedRequestConfig){
@@ -84,7 +82,7 @@ function mockTemplate() {
 
             // Response interceptors are invoked in reverse order as per docs
             for (var i = interceptors.length - 1; i >= 0; i--) {
-                var interceptor = getInterceptor(interceptors[i]);
+                var interceptor = interceptors[i];
 
                 if (interceptor.response && statusIsSuccessful(response.status)) {
                     $q.when(interceptor.response(response)).then(function(interceptedResponse){

--- a/lib/httpMock.js
+++ b/lib/httpMock.js
@@ -18,8 +18,12 @@ function mockTemplate() {
         var interceptors = [];
 
         angular.forEach($httpProvider.interceptors, function(interceptorExpression) {
-            var interceptor = angular.isString(interceptorExpression) ?
-                $injector.get(interceptorExpression) : $injector.invoke(interceptorExpression);
+            var interceptor;
+            if (angular.isString(interceptorExpression)) {
+                interceptor = $injector.get(interceptorExpression);
+            } else {
+                interceptor = $injector.invoke(interceptorExpression);
+            }
             interceptors.push(interceptor);
         });
 

--- a/tests/interceptors.test.js
+++ b/tests/interceptors.test.js
@@ -43,6 +43,18 @@ describe('interceptors', function(){
 			}
 		});
 
+		$httpProvider.interceptors.push(function(){
+			var count = 0;
+			return {
+				response: function(response){
+					count++;
+					response.headers['stateful-anonymous-response-count'] = count;
+
+					return response;
+				}
+			}
+		});
+
 		$httpProvider.interceptors.push(['$q', function($q){
 			return {
 				request: function(config){
@@ -111,6 +123,21 @@ describe('interceptors', function(){
 		}).then(function(response){
 			expect(response.data.name).toBe('anonymous intercept test');
 			expect(response.data.interceptedResponse).toBeTruthy();
+			done();
+		});
+	});
+
+	it('allows for intercepts through stateful anonymous factory', function(done){
+		http({
+			method: 'GET',
+			url: 'test-url.com/anonymous-intercept'
+		}).then(function(){
+			return http({
+				method: 'GET',
+				url: 'test-url.com/anonymous-intercept'
+			});
+		}).then(function(response){
+			expect(response.headers['stateful-anonymous-response-count']).toBeGreaterThan(1);
 			done();
 		});
 	});


### PR DESCRIPTION
If an interceptor is a anonymous factory (e.g. via `$httpProvider.interceptors.push(['$q', function($q) {...}])`), the interceptor is created multiple times during the test life cycle. If such interceptor is a stateful singleton like the [Angular Loading Bar](https://github.com/chieffancypants/angular-loading-bar), the state is ambiguous.

The PR fixes the problem by instantiating the interceptors once and reuses the instances. 